### PR TITLE
Feature/front tests

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -57,9 +57,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "fetch-mock": "^8.0.1",
-    "ts-jest": "^24.2.0"
   }
 }

--- a/front/package.json
+++ b/front/package.json
@@ -29,6 +29,23 @@
   "eslintConfig": {
     "extends": "react-app"
   },
+  "jest": {
+    "collectCoverageFrom": [
+      "**/*.ts",
+      "!*/models/*",
+      "!**/index.ts",
+      "!*/config.ts",
+      "!*/react-app-env.d.ts"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": -10
+      }
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",
@@ -40,5 +57,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "fetch-mock": "^8.0.1",
+    "ts-jest": "^24.2.0"
   }
 }

--- a/front/src/helpers/http-client.test.ts
+++ b/front/src/helpers/http-client.test.ts
@@ -1,0 +1,121 @@
+import { httpClient } from "./http-client";
+import { User } from "../models";
+import { AuthenticationService } from "../services";
+import { arrayOf } from "prop-types";
+
+const fetch = jest.spyOn(global, 'fetch');
+const isLoggedIn = jest.spyOn(AuthenticationService, "isLoggedIn", "get");
+
+const user: User = {
+    id: 1,
+    username: 'testuser',
+    email: 'testuser@test.ts',
+    token: 'aaaa'
+};
+
+beforeEach(() => {
+    jest.resetAllMocks();
+});
+
+test('HTTP GET', async () => {
+    fetch.mockResolvedValueOnce<Response>({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(user)
+    });
+    await httpClient.get<User>('account/', false).then(u => expect(u).toBe(user));
+});
+
+test('HTTP authenticated GET', async () => {
+    fetch.mockResolvedValueOnce<Response>({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(user)
+    });
+    isLoggedIn.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    jest.spyOn(AuthenticationService, "user", "get").mockReturnValue(user);
+    await httpClient.get<User>('account/', true).then(u => {
+        let requestOptions: RequestInit = fetch.mock.calls[0][1];
+        expect(requestOptions).toHaveProperty('headers');
+        expect((requestOptions.headers as Headers).get('Authorization')).toBe(`JWT ${user.token}`);
+        expect(u).toBe(user);
+    })
+    await httpClient.get<User>('account/', true).catch(() => {
+        expect(isLoggedIn.mock.calls).toHaveLength(2);
+        expect(fetch.mock.calls).toHaveLength(1);
+    });
+    expect.assertions(5);
+});
+
+test('HTTP GET Status Error', async () => {
+    fetch.mockResolvedValueOnce<Response>({
+        ok: false,
+        status: 404,
+        statusText: 'User not found',
+        json: () => Promise.reject()
+    });
+    expect.assertions(1);
+    await httpClient.get<User>('account/', false).catch(e => expect(e).toBe('User not found'));
+});
+
+test('HTTP GET User-friendly Error', async () => {
+    const body = { message: 'This user does not exist'};
+    fetch.mockResolvedValueOnce<Response>({
+        ok: false,
+        status: 404,
+        statusText: 'User not found',
+        json: () => Promise.resolve(body)
+    });
+    expect.assertions(1);
+    await httpClient.get<User>('account/').catch(e => expect(e).toBe(body.message));
+});
+
+test('HTTP GET Network error', async () => {
+    const error = new ErrorEvent('NetworkError', { message: 'Could not reach host' });
+    fetch.mockRejectedValueOnce(error);
+    expect.assertions(1);
+    await httpClient.get<User>('account/', false).catch(e => expect(e).toBe(error.message));
+});
+
+test('HTTP POST', async () => {
+    fetch.mockResolvedValueOnce<Response>({
+        ok: true,
+        status: 201,
+        json: () => Promise.resolve(user)
+    });
+    await httpClient.post<User>('account/', user).then(u => {
+        expect((fetch.mock.calls[0][1] as RequestInit).body).toBe(JSON.stringify(user));
+        expect(((fetch.mock.calls[0][1] as RequestInit).headers as Headers).get('Content-Type')).toBe('application/json');
+        expect(u).toBe(user);
+    });
+});
+
+test('HTTP PUT', async () => {
+    fetch.mockResolvedValueOnce<Response>({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(user)
+    });
+    await httpClient.put<User>('account/', user).then(u => {
+        expect((fetch.mock.calls[0][1] as RequestInit).body).toBe(JSON.stringify(user));
+        expect(((fetch.mock.calls[0][1] as RequestInit).headers as Headers).get('Content-Type')).toBe('application/json');
+        expect(u).toBe(user);
+    });
+});
+
+test('HTTP DELETE', async () => {
+    fetch.mockResolvedValueOnce<Response>(new Response(null, { status: 200 }));
+    await httpClient.delete('account/').then(u => {
+        expect(u).toBeNull();
+        expect(((fetch.mock.calls[0][1] as RequestInit).headers as Headers).get('Content-Type')).toBeNull();
+    });
+});
+
+test('HTTP DELETE Status error', async () => {
+    fetch.mockResolvedValueOnce<Response>(new Response(null, { status: 404, statusText: 'User not found' }));
+    expect.assertions(2);
+    await httpClient.delete('account/').catch(error => {
+        expect(((fetch.mock.calls[0][1] as RequestInit).headers as Headers).get('Content-Type')).toBeNull();
+        expect(error).toBe('User not found');
+    });
+});

--- a/front/src/helpers/http-client.ts
+++ b/front/src/helpers/http-client.ts
@@ -13,12 +13,12 @@ export class httpClient {
      */
     private static headers(authenticated: boolean, body: boolean): Headers {
         const headers = new Headers();
-        if (authenticated && AuthenticationService.isLoggedIn && AuthenticationService.user.token) {
-            headers.append('Authorization', 'JWT ' + AuthenticationService.user.token);
-        }
-        if (body) {
+        if (authenticated && AuthenticationService.isLoggedIn && AuthenticationService.user.token)
+            headers.append('Authorization', `JWT ${AuthenticationService.user.token}`);
+        else if (authenticated)
+            throw new Error('User is not authenticated');
+        if (body)
             headers.append('Content-Type', 'application/json');
-        }
         headers.append('Accept', 'application/json');
         return headers;
     }
@@ -47,13 +47,13 @@ export class httpClient {
     /**
      * Handles an HTTP response depending on its status.
      * @param response the Response to handle
-     * @returns A Promise containing the parsed JSON of the body, or an error.
+     * @returns A Promise containing the parsed JSON of the body or null if no body is provided
      */
     private static async handleResponse(response: Response): Promise<any> {
         if (!response.ok) {
             return response.json().then(({message}) => Promise.reject(message), () => Promise.reject(response.statusText));
         }
-        return response.json();
+        return response.json().catch(() => null);
     }
 
     /**
@@ -85,33 +85,32 @@ export class httpClient {
     /**
      * Sends a HTTP POST request.
      * @param endpoint The endpoint to send the request to, as a *non-absolute* URL
+     * @param body The body, of type T, of the request
      * @param authenticated Indicates whether the request should be authenticated.
-     * @param body Contains the body of the request, as a string, if need be.
      * @returns A promise containing an object of type T
      */
-    public static async post<T>(endpoint: string, authenticated = false, body = ''): Promise<T> {
-        return await this.request<T>(endpoint, this.options(authenticated, 'POST', body));
+    public static async post<T>(endpoint: string, body: T, authenticated = false): Promise<T> {
+        return await this.request<T>(endpoint, this.options(authenticated, 'POST', JSON.stringify(body)));
     }
 
     /**
      * Sends a HTTP PUT request.
      * @param endpoint The endpoint to send the request to, as a *non-absolute* URL
+     * @param body The body, of type T, of the request
      * @param authenticated Indicates whether the request should be authenticated.
-     * @param body Contains the body of the request, as a string, if need be.
      * @returns A promise containing an object of type T
      */
-    public static async put<T>(endpoint: string, authenticated = false, body = ''): Promise<T> {
-        return await this.request<T>(endpoint, this.options(authenticated, 'PUT', body));
+    public static async put<T>(endpoint: string, body: T, authenticated = false): Promise<T> {
+        return await this.request<T>(endpoint, this.options(authenticated, 'PUT', JSON.stringify(body)));
     }
 
     /**
      * Sends a HTTP DELETE request.
      * @param endpoint The endpoint to send the request to, as a *non-absolute* URL
      * @param authenticated Indicates whether the request should be authenticated.
-     * @param body Contains the body of the request, as a string, if need be.
-     * @returns A promise containing an object of type T
+     * @returns A promise containing null
      */
-    public static async delete<T>(endpoint: string, authenticated = false, body = ''): Promise<T> {
-        return await this.request<T>(endpoint, this.options(authenticated, 'DELETE', body));
+    public static async delete(endpoint: string, authenticated = false): Promise<null> {
+        return await this.request<null>(endpoint, this.options(authenticated, 'DELETE'));
     }
 }

--- a/front/src/models/User.ts
+++ b/front/src/models/User.ts
@@ -1,6 +1,7 @@
 export interface User {
-	id: number;
-	username: string;
-	email: string;
+	id?: number;
+	username?: string;
+    email: string;
+    password?: string;
 	token?: string;
 }

--- a/front/src/services/authentication.service.test.ts
+++ b/front/src/services/authentication.service.test.ts
@@ -1,0 +1,60 @@
+import { httpClient, history } from "../helpers";
+import { User } from "../models";
+import { AuthenticationService } from "./authentication.service";
+
+const user: User = {
+    id: 1,
+    username: 'testuser',
+    email: 'testuser@test.ts',
+    token: 'aaaa'
+};
+
+const post = jest.spyOn(httpClient, "post");
+const historySpy = jest.spyOn(history, "push");
+
+beforeEach(() => {
+    AuthenticationService.logout();
+    historySpy.mockClear();
+})
+
+test('Successful login', async () => {
+    post.mockResolvedValueOnce(user);
+    await AuthenticationService.login(user.email, 'password').then(u => {
+        expect(u).toBe(user);
+        expect(historySpy).toHaveBeenCalled();
+        expect(AuthenticationService.isLoggedIn).toBe(true);
+    });
+});
+
+test('Failed login', async () => {
+    post.mockRejectedValueOnce({ message: 'Wrong password' });
+    await AuthenticationService.login(user.email, 'wrongpassword').catch(e => {
+        expect(e).toBe('Identifiants incorrects');
+        expect(historySpy).not.toHaveBeenCalled();
+        expect(AuthenticationService.isLoggedIn).toBe(false);
+    });
+    expect.assertions(3);
+});
+
+test('Register success', async () => {
+    post.mockResolvedValueOnce(user);
+    await AuthenticationService.register('usertest', 'testuser@test.ts', 'password').then(u => {
+        expect(u).toBe(user);
+    });
+});
+
+test('Register failure', async () => {
+    post.mockRejectedValueOnce({ message: 'E-mail already exists' });
+    await AuthenticationService.register('usertest', 'existingemail@test.ts', 'password').catch(e => {
+        expect(e).toBe('Création du compte impossible ; veuillez réessayer.');
+        expect(historySpy).not.toHaveBeenCalled();
+    });
+    expect.assertions(2);
+});
+
+test('Retrieve user', async () => {
+    expect(AuthenticationService.user).toStrictEqual({} as User);
+    post.mockResolvedValueOnce(user);
+    await AuthenticationService.login('testemail@test.ts', 'password');
+    expect(AuthenticationService.user).toStrictEqual(user);
+});

--- a/front/src/services/authentication.service.ts
+++ b/front/src/services/authentication.service.ts
@@ -11,7 +11,7 @@ export class AuthenticationService {
      * @returns The user as sent by the API
      */
     static async login(email: string, password: string): Promise<User> {
-        return httpClient.post<User>('/auth/login', false, JSON.stringify({ email, password })).then(user => {
+        return httpClient.post<User>('/auth/login', { email: email, password: password }).then(user => {
             localStorage.setItem('user', JSON.stringify(user));
             history.push('/');
             return user;
@@ -26,7 +26,7 @@ export class AuthenticationService {
      * @returns The user as registered by the API
      */
     static async register(username: string, email: string, password: string): Promise<User> {
-        return httpClient.post<User>('/auth/register', false, JSON.stringify({ username, email, password })).then(null, () => Promise.reject('Création du compte impossible ; veuillez réessayer.'));
+        return httpClient.post<User>('/auth/register', { username: username, email: email, password: password }).then(null, () => Promise.reject('Création du compte impossible ; veuillez réessayer.'));
     }
     
     /**


### PR DESCRIPTION
### Changes

This adds unit tests to the front (for the time being, those are only for .ts file, not .tsx ones.

This also changes the signature of `httpClient.post()`, `.put()` and `.delete()` functions. Now the body of a POST or PUT request must be of the same type as the one expected in the answer, and a DELETE request should not have a body (and **does not expect one in return**). This is consistent with HTTP requests specifications.

Finally, error messages sent by the API should send a response with a status text, and could populate the body with a JSON object with the following structure:
```javascript
{message: 'The error message'}
```
This is consistent with what is usually done in the industry. (And at any rate, as the back is in English but the front in French, those messages will not be displayed in the UI…)

### Testing
You can try registering and logging in; it should work as before.

You can execute the tests by running the following:
```
cd front
yarn test --coverage --watchAll
```